### PR TITLE
feat: Add responsive landing page with light and dark mode

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,29 @@
+import { ChatInput } from "@/components/widgets/chat-input";
+import { Chat } from "@/components/chat";
+import Link from "next/link";
+import ThemeSwitcher from "@/components/theme-switchr";
+import { Github } from "lucide-react";
+
+export default function ChatPage() {
+	return (
+		<div className="h-screen w-[97%] md:w-[60%] relative mx-auto items-center !pb-4 flex flex-col">
+			<h1 className="italic text-3xl fraunces w-full flex justify-between pt-4 sm:fixed left-6 items-center select-none sm:px-0 px-4 pb-3">
+				<span className="!text-[#5e7e5f] dark:!text-white/85">Talaash</span>
+
+				<div className="sm:fixed right-6 flex gap-3">
+					<ThemeSwitcher />
+
+					<Link
+						href="https://github.com/imrofayel/talaash-chat"
+						className="geist font-normal text-lg bg-green-100/50 dark:bg-emerald-950/50 text-slate-800 dark:text-white/85 flex p-2 rounded-lg items-center border border-slate-400/50 dark:border-white/20 gap-2"
+					>
+						<Github className="w-6 h-6" />
+						<span>Star</span>
+					</Link>
+				</div>
+			</h1>
+			<Chat />
+			<ChatInput />
+		</div>
+	);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,38 +1,305 @@
-import { ChatInput } from "@/components/widgets/chat-input";
-import { Chat } from "@/components/chat";
+// app/page.tsx
+"use client";
+
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import ThemeSwitcher from "@/components/theme-switchr";
+import { AppUIPeeker } from "@/components/AppUIPeeker";
 
-export default function Home() {
+export default function LandingPage() {
+	const [isMounted, setIsMounted] = useState(false);
+
+	useEffect(() => {
+		setIsMounted(true);
+	}, []);
+
 	return (
-		<div className="h-screen w-[97%] md:w-[60%] relative mx-auto items-center !pb-4 flex flex-col">
-			<h1 className="italic text-3xl fraunces w-full flex justify-between pt-4 sm:fixed left-6 items-center select-none sm:px-0 px-4 pb-3">
-				<span className="!text-[#5e7e5f] dark:!text-white/85">Talaash</span>
-
-				<div className="sm:fixed right-6 flex gap-3">
-					<ThemeSwitcher />
-
+		<div className="geist bg-background text-foreground min-h-screen flex flex-col">
+			{/* HEADER */}
+			<header className="container mx-auto px-6 py-4 flex justify-between items-center">
+				<h1 className="text-2xl font-bold fraunces flex items-center gap-2">
+					<div className="i-hugeicons:compass-01 w-7 h-7 text-primary" />
+					Talaash
+				</h1>
+				<div className="flex items-center gap-4">
+					{/* Go to App – now same style as View on GitHub */}
 					<Link
-						href="https://github.com/imrofayel/talaash-chat"
-						className="geist font-normal text-[19px] dark:!bg-emerald-950 bg-[#e5f0df] dark:!text-white/85 flex p-1 rounded-lg justify-center items-center border gap-1 dark:border-white/10 border-[#899c8d] px-1.5"
+						href="/chat"
+						className="group inline-flex items-center gap-3 
+                       bg-card text-foreground hover:bg-accent 
+                       border border-border 
+                       rounded-xl px-6 py-3 font-semibold text-sm 
+                       transition-all duration-300 hover:scale-105"
 					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							viewBox="0 0 24 24"
-						>
-							<title>GitHub Icons</title>
-							<path
-								fill="currentColor"
-								d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33s1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2"
-							/>
-						</svg>
-						<span>Star</span>
+						<div className="i-hugeicons:message-circle-02 w-5 h-5" />
+						Go to App
 					</Link>
+					<ThemeSwitcher />
 				</div>
-			</h1>
-			<Chat />
-			<ChatInput />
+			</header>
+
+			{/* MAIN CONTENT */}
+			<main
+				className={`flex-1 container mx-auto px-6 py-16 text-center transition-opacity duration-1000 ${
+					isMounted ? "opacity-100" : "opacity-0"
+				}`}
+			>
+				{/* HERO SECTION */}
+				<section className="mb-20">
+					<h2 className="text-5xl md:text-7xl font-extrabold mb-6 fraunces bg-clip-text text-transparent bg-gradient-to-r from-primary via-secondary to-primary animate-gradient-x">
+						A New Conversation Begins
+					</h2>
+					<p className="text-xl md:text-2xl text-muted-foreground max-w-4xl mx-auto mb-12 leading-relaxed">
+						Your elegant, open-source gateway to the world's leading AI models.
+						Chat, compare, and create — all from one beautifully simple
+						interface that brings the future of AI to your fingertips.
+					</p>
+
+					{/* LIVE PREVIEW */}
+					<div className="flex flex-col items-center gap-8">
+						<div className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+							Experience AI Like Never Before
+						</div>
+						<AppUIPeeker />
+
+						{/* Live Chat Preview */}
+						<div className="w-full max-w-2xl bg-card/50 backdrop-blur-sm border rounded-2xl p-6 shadow-2xl">
+							<div className="flex items-center justify-between mb-4">
+								<div className="flex items-center gap-3">
+									<div className="i-hugeicons:robot w-5 h-5 text-primary" />
+									<span className="font-medium">DeepSeek V3</span>
+									<div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+								</div>
+								<div className="text-xs text-muted-foreground">
+									Live Preview
+								</div>
+							</div>
+							<div className="space-y-3">
+								<div className="bg-muted/30 rounded-lg p-3 text-sm">
+									<span className="text-muted-foreground">You:</span> How’s your
+									day going?
+								</div>
+								<div className="bg-primary/10 rounded-lg p-3 text-sm">
+									<span className="text-primary font-medium">AI:</span> Hello
+									there! ✨ Hope it’s amazing! ✨
+								</div>
+							</div>
+							<div className="mt-4 flex items-center justify-center gap-2 text-xs text-muted-foreground">
+								<span>Powered by OpenRouter</span>
+								<div className="w-1 h-1 bg-muted-foreground rounded-full" />
+								<span>Real-time responses</span>
+							</div>
+						</div>
+
+						{/* STACK INFO */}
+						<div className="flex flex-wrap items-center justify-center gap-6 text-sm text-muted-foreground">
+							<div className="flex items-center gap-2">
+								<div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+								<span>Next.js 14</span>
+							</div>
+							<div className="flex items-center gap-2">
+								<div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
+								<span>OpenRouter Integration</span>
+							</div>
+							<div className="flex items-center gap-2">
+								<div className="w-2 h-2 bg-purple-500 rounded-full animate-pulse" />
+								<span>TypeScript</span>
+							</div>
+							<div className="flex items-center gap-2">
+								<div className="w-2 h-2 bg-orange-500 rounded-full animate-pulse" />
+								<span>Tailwind CSS</span>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				{/* CTA Section */}
+				<section className="mb-16">
+					<div className="rounded-3xl p-12 border border-primary/20 text-center">
+						<h3 className="text-3xl md:text-4xl font-bold mb-6 fraunces">
+							Ready to Experience the Future of AI Chat?
+						</h3>
+						<p className="text-lg text-muted-foreground mb-8 max-w-3xl mx-auto">
+							Join thousands of developers, researchers, and AI enthusiasts who
+							have discovered the power of unified AI access. Start your
+							intelligent conversation today.
+						</p>
+
+						{/* Buttons */}
+						<div className="flex flex-col sm:flex-row gap-6 justify-center items-center">
+							<Link
+								href="/chat"
+								className="group inline-flex items-center gap-3 bg-primary hover:bg-primary/90 text-primary-foreground rounded-xl px-8 py-4 font-semibold text-lg transition-all duration-300 hover:scale-105"
+							>
+								<div className="i-hugeicons:message-circle-02 w-6 h-6" />
+								Start Chatting Now
+								<div className="i-hugeicons:arrow-right-02 w-5 h-5" />
+							</Link>
+							<a
+								href="https://github.com/imrofayel/talaash-chat"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="group inline-flex items-center gap-3 bg-card text-foreground hover:bg-accent border border-border rounded-xl px-8 py-4 font-semibold text-lg transition-all duration-300 hover:scale-105"
+							>
+								<div className="i-hugeicons:github w-6 h-6" />
+								View on GitHub
+							</a>
+						</div>
+					</div>
+				</section>
+
+				{/* Why Choose Talaash */}
+				<section className="mb-20 text-left">
+					<div className="text-center mb-16">
+						<h3 className="text-4xl md:text-5xl font-bold mb-6 fraunces bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400">
+							Why Choose Talaash?
+						</h3>
+						<p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+							Discover the advantages that make Talaash the preferred choice for
+							AI enthusiasts and professionals worldwide.
+						</p>
+					</div>
+					<div className="grid md:grid-cols-2 gap-8 max-w-6xl mx-auto">
+						<div className="p-8 bg-gradient-to-br from-primary/8 via-primary/4 to-secondary/8 border border-primary/20 rounded-2xl transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl relative">
+							<div className="flex items-center gap-4 mb-6 relative z-10">
+								<div className="p-3 bg-primary/10 rounded-xl">
+									<div className="i-hugeicons:layout-grid w-7 h-7 text-primary" />
+								</div>
+								<h4 className="text-2xl font-bold">
+									Unified Access, Zero Clutter
+								</h4>
+							</div>
+							<p className="text-muted-foreground leading-relaxed text-lg relative z-10">
+								Stop juggling tabs and multiple platforms. Talaash provides a
+								single, beautifully designed <strong>Next.js</strong> interface
+								to interact with diverse AI models via{" "}
+								<strong>OpenRouter's</strong> extensive catalog.
+							</p>
+							<div className="mt-6 flex items-center gap-2 text-sm font-medium text-primary relative z-10">
+								<span>OpenRouter API</span>
+								<div className="w-1 h-1 bg-primary rounded-full" />
+								<span>TypeScript</span>
+							</div>
+						</div>
+
+						<div className="p-8 bg-gradient-to-br from-emerald-500/8 via-emerald-500/4 to-blue-500/8 border border-emerald-500/20 rounded-2xl transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl relative">
+							<div className="flex items-center gap-4 mb-6 relative z-10">
+								<div className="p-3 bg-emerald-500/10 rounded-xl">
+									<div className="i-hugeicons:open-source w-7 h-7 text-emerald-600 dark:text-emerald-400" />
+								</div>
+								<h4 className="text-2xl font-bold">Free and Open Source</h4>
+							</div>
+							<p className="text-muted-foreground leading-relaxed text-lg relative z-10">
+								Built for the community, by the community. Explore cutting-edge
+								AI models completely free through our{" "}
+								<strong>MIT-licensed</strong> codebase. Contribute to a project
+								that champions open access and collaborative innovation.
+							</p>
+							<div className="mt-6 flex items-center gap-2 text-sm font-medium text-emerald-600 dark:text-emerald-400 relative z-10">
+								<span>MIT Licensed</span>
+								<div className="w-1 h-1 bg-emerald-500 rounded-full" />
+								<span>Community Driven</span>
+								<div className="w-1 h-1 bg-emerald-500 rounded-full" />
+								<span>Modern Stack</span>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				{/* How It Works */}
+				<section className="mb-20">
+					<h3 className="text-3xl font-bold mb-10 text-center fraunces">
+						How It Works
+					</h3>
+					<div className="grid md:grid-cols-3 gap-8">
+						<div className="group p-6 bg-gradient-to-br from-blue-500/5 to-purple-500/5 hover:from-blue-500/10 hover:to-purple-500/10 border border-blue-500/10 rounded-xl transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
+							<div className="i-hugeicons:flash-on w-8 h-8 mx-auto mb-4 text-blue-600 dark:text-blue-400" />
+							<h4 className="text-xl font-semibold mb-3">Select Your Model</h4>
+							<p className="text-muted-foreground">
+								Instantly switch between models like Llama 3, Mistral, and
+								GPT-4o from a simple dropdown menu.
+							</p>
+						</div>
+						<div className="group p-6 bg-gradient-to-br from-purple-500/5 to-pink-500/5 hover:from-purple-500/10 hover:to-pink-500/10 border border-purple-500/10 rounded-xl transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
+							<div className="i-hugeicons:message-circle-02 w-8 h-8 mx-auto mb-4 text-purple-600 dark:text-purple-400" />
+							<h4 className="text-xl font-semibold mb-3">
+								Start Your Conversation
+							</h4>
+							<p className="text-muted-foreground">
+								Enjoy a clean, markdown-supported chat experience with a
+								familiar, modern user interface.
+							</p>
+						</div>
+						<div className="group p-6 bg-gradient-to-br from-orange-500/5 to-red-500/5 hover:from-orange-500/10 hover:to-red-500/10 border border-orange-500/10 rounded-xl transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
+							<div className="i-hugeicons:github-01 w-8 h-8 mx-auto mb-4 text-orange-600 dark:text-orange-400" />
+							<h4 className="text-xl font-semibold mb-3">
+								Contribute on GitHub
+							</h4>
+							<p className="text-muted-foreground">
+								Our codebase is open. Fork the repo, add a feature, and be a
+								part of the journey.
+							</p>
+						</div>
+					</div>
+				</section>
+			</main>
+
+			{/* FOOTER - cleaned */}
+			<footer className="bg-card px-6 py-12">
+				<div className="container mx-auto grid grid-cols-1 md:grid-cols-3 gap-10">
+					{/* About */}
+					<div className="md:col-span-2">
+						<h3 className="fraunces text-2xl font-bold mb-3 flex items-center gap-2">
+							<div className="i-hugeicons:compass-01 w-5 h-5 text-primary" />
+							Talaash
+						</h3>
+						<p className="text-muted-foreground max-w-md">
+							Your open-source gateway to top AI models. Modern, secure, and
+							100% free — built for the community.
+						</p>
+					</div>
+
+					{/* Project Links */}
+					<div>
+						<h4 className="font-semibold mb-3">Project</h4>
+						<ul className="space-y-1 text-sm text-muted-foreground">
+							<li>
+								<a
+									href="https://github.com/imrofayel/talaash-chat"
+									className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<div className="i-hugeicons:github w-5 h-5" />
+									View on GitHub
+								</a>
+							</li>
+							<li className="inline-flex items-center gap-2 text-muted-foreground">
+								<div className="i-hugeicons:lock-square w-5 h-5 text-primary" />
+								MIT License
+							</li>
+							<li className="inline-flex items-center gap-2 text-muted-foreground">
+								<div className="i-hugeicons:support w-5 h-5 text-primary" />
+								Support:{" "}
+								<a
+									href="mailto:support@talaash.chat"
+									className="underline hover:text-primary ml-1"
+								>
+									support@talaash.chat
+								</a>
+							</li>
+						</ul>
+					</div>
+				</div>
+
+				{/* Footer Bottom */}
+				<div className="container mx-auto flex flex-col sm:flex-row items-center justify-between py-4 text-sm text-muted-foreground mt-10">
+					<span>
+						&copy; {new Date().getFullYear()} Talaash. All rights reserved.
+					</span>
+					<span>Open source & secure AI access for everyone.</span>
+				</div>
+			</footer>
 		</div>
 	);
 }

--- a/components/AppUIPeeker.tsx
+++ b/components/AppUIPeeker.tsx
@@ -1,0 +1,13 @@
+// components/AppUIPeeker.tsx
+import type React from "react";
+
+export const AppUIPeeker: React.FC = () => (
+	<div className="mt-8 flex justify-center">
+		{/* Simulated model picker */}
+		<div className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm">
+			<div className="i-hugeicons:robot w-5 h-5 text-primary" />
+			<span className="font-medium">Llama 3 8B</span>
+			<div className="i-hugeicons:chevron-down w-4 h-4 text-muted-foreground" />
+		</div>
+	</div>
+);

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.1.2",
 		"@eslint/eslintrc": "^3",
+		"@iconify-json/hugeicons": "^1.2.8",
 		"@iconify-json/solar": "^1.2.2",
 		"@iconify-json/vscode-icons": "^1.2.23",
 		"@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.0
+      '@iconify-json/hugeicons':
+        specifier: ^1.2.8
+        version: 1.2.8
       '@iconify-json/solar':
         specifier: ^1.2.2
         version: 1.2.2
@@ -221,24 +224,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.1.2':
     resolution: {integrity: sha512-NWNy2Diocav61HZiv2enTQykbPP/KrA/baS7JsLSojC7Xxh2nl9IczuvE5UID7+ksRy2e7yH7klm/WkA72G1dw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.1.2':
     resolution: {integrity: sha512-xlB3mU14ZUa3wzLtXfmk2IMOGL+S0aHFhSix/nssWS/2XlD27q+S6f0dlQ8WOCbYoXcuz8BCM7rCn2lxdTrlQA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.1.2':
     resolution: {integrity: sha512-Km/UYeVowygTjpX6sGBzlizjakLoMQkxWbruVZSNE6osuSI63i4uCeIL+6q2AJlD3dxoiBJX70dn1enjQnQqwA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.1.2':
     resolution: {integrity: sha512-G8KWZli5ASOXA3yUQgx+M4pZRv3ND16h77UsdunUL17uYpcL/UC7RkWTdkfvMQvogVsAuz5JUcBDjgZHXxlKoA==}
@@ -498,6 +505,9 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify-json/hugeicons@1.2.8':
+    resolution: {integrity: sha512-Z5BiwYQ/eOwDx21DzVbFE5/2919P10LNQ0DbzOiJBqwF6uAFw1QvI5AUREHBE26RGLgq+b8frv5xY1baGMqV6A==}
+
   '@iconify-json/solar@1.2.2':
     resolution: {integrity: sha512-lcTb6DWL4HZObiY1W3fHfuxxuQHUc6CFHFeywKEx7Ry0k+dU6POZCMC7oVLr0F8vuf+KgaQ3oOoGO/yFzOwrNg==}
 
@@ -536,67 +546,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -654,24 +676,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.2.0':
     resolution: {integrity: sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.2.0':
     resolution: {integrity: sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.2.0':
     resolution: {integrity: sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.2.0':
     resolution: {integrity: sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==}
@@ -1090,56 +1116,67 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -1227,24 +1264,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.0.9':
     resolution: {integrity: sha512-3eMjyTC6HBxh9nRgOHzrc96PYh1/jWOwHZ3Kk0JN0Kl25BJ80Lj9HEvvwVDNTgPg154LdICwuFLuhfgH9DULmg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.0.9':
     resolution: {integrity: sha512-v0D8WqI/c3WpWH1kq/HP0J899ATLdGZmENa2/emmNjubT0sWtEke9W9+wXeEoACuGAhF9i3PO5MeyditpDCiWQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.0.9':
     resolution: {integrity: sha512-Kvp0TCkfeXyeehqLJr7otsc4hd/BUPfcIGrQiwsTVCfaMfjQZCG7DjI+9/QqPZha8YapLA9UoIcUILRYO7NE1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.0.9':
     resolution: {integrity: sha512-m3+60T/7YvWekajNq/eexjhV8z10rswcz4BC9bioJ7YaN+7K8W2AmLmG0B79H14m6UHE571qB0XsPus4n0QVgQ==}
@@ -2880,24 +2921,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.29.1:
     resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.29.1:
     resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.29.1:
     resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.29.1:
     resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
@@ -4362,6 +4407,10 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.2': {}
+
+  '@iconify-json/hugeicons@1.2.8':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify-json/solar@1.2.2':
     dependencies:


### PR DESCRIPTION
This PR introduces a new landing page for Talaash-Chat as requested in issue #8.
Features:
Follows the sitemap structure (Intro, Features, CTA, Footer).
Includes both light and dark mode.
Uses next-themes for theme switching.
The page is responsive and uses the existing Tailwind CSS styles for consistency.
How to Test:
Run the app with pnpm dev.
Navigate to the homepage.
Use the theme switcher in the header to toggle between light and dark modes.
