### PR TITLE
chore(coc): Add Contributor Covenant v2.1 + GSSoC addendum

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -39,7 +39,7 @@ All complaints will be reviewed and investigated promptly and fairly. The team i
 ### For GSSoC Contributors
 Instances of abusive, harassing, or otherwise unacceptable behavior can be reported to:  
 📧 [gssoc@girlscript.tech](mailto:gssoc@girlscript.tech)  
-💬 Backup contact via Discord: Join the [GSSoC 2025 Server](<YOUR_SERVER_INVITE_LINK_HERE>)
+💬 Backup contact via Discord: Join the [GSSoC 2025 Server](https://discord.com/invite/BjdgNbPMJR)
 
 ## 📖 Enforcement Guidelines
 
@@ -56,8 +56,8 @@ Instances of abusive, harassing, or otherwise unacceptable behavior can be repor
 - Respect project admins, mentors, and fellow participants throughout the program.  
 
 ## 📜 Attribution
-This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  
-Enforcement guidelines inspired by [Mozilla’s code of conduct enforcement ladder](https://www.mozilla.org/en-US/about/governance/policies/participation/enforcement/).
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).  
+Enforcement guidelines inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion/blob/master/code-of-conduct-enforcement/consequence-ladder.md).
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -39,7 +39,7 @@ All complaints will be reviewed and investigated promptly and fairly. The team i
 ### For GSSoC Contributors
 Instances of abusive, harassing, or otherwise unacceptable behavior can be reported to:  
 📧 [gssoc@girlscript.tech](mailto:gssoc@girlscript.tech)  
-💬 Backup contact via Discord: [GSSoC 2025 Server](https://discord.com/channels/1378815292729327728/1390011139529642004)
+💬 Backup contact via Discord: Join the [GSSoC 2025 Server](<YOUR_SERVER_INVITE_LINK_HERE>)
 
 ## 📖 Enforcement Guidelines
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# 🌟 Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## 🚦 Our Standards
+
+### Positive Behavior
+- 💖 Demonstrating empathy and kindness toward others  
+- 🤝 Being respectful of differing opinions, viewpoints, and experiences  
+- 📝 Giving and gracefully accepting constructive feedback  
+- 🌱 Accepting responsibility and apologizing to those affected by mistakes, and learning from the experience  
+- 🎯 Focusing on what is best for the overall community  
+
+### Unacceptable Behavior
+- 🚫 Use of sexualized language or imagery, and unwelcome sexual attention or advances  
+- 🛑 Trolling, insulting or derogatory comments, and personal or political attacks  
+- ⚠️ Public or private harassment  
+- 🔒 Publishing others' private information (such as a physical or email address) without explicit permission  
+- ❌ Other conduct that could reasonably be considered inappropriate in a professional setting  
+
+## 🛡️ Enforcement Responsibilities
+Community leaders, project admins, and maintainers are responsible for clarifying and enforcing our standards of acceptable behavior. They may take appropriate and fair corrective action in response to behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Leaders have the right and responsibility to remove, edit, or reject contributions not aligned with this Code of Conduct, providing reasons for moderation when appropriate.
+
+## 🌐 Scope
+This Code of Conduct applies across all community spaces — including GitHub repositories, communication platforms, events, and social media — as well as any interactions where individuals are officially representing the project in public or private spaces.
+
+## 📋 Reporting & Enforcement
+
+### For All Contributors
+Instances of abusive, harassing, or otherwise unacceptable behavior can be reported through our GitHub Issues page:  
+📌 [Report an Issue](https://github.com/imrofayel/Talaash-Chat/issues/10)  
+All complaints will be reviewed and investigated promptly and fairly. The team is committed to protecting the privacy and safety of the reporter.
+
+### For GSSoC Contributors
+Instances of abusive, harassing, or otherwise unacceptable behavior can be reported to:  
+📧 [gssoc@girlscript.tech](mailto:gssoc@girlscript.tech)  
+💬 Backup contact via Discord: [GSSoC 2025 Server](https://discord.com/channels/1378815292729327728/1390011139529642004)
+
+## 📖 Enforcement Guidelines
+
+| Impact | Consequence |
+|--------|------------|
+| ✏️ **Correction** | Private warning and clarification of the violation. A public apology may be requested. |
+| ⚠️ **Warning** | Official warning for a clear violation. Avoid further interaction with affected parties for a specific time. Repeated violations may lead to a temporary or permanent ban. |
+| ⏳ **Temporary Ban** | Temporary ban from participation in the community. No public or private interactions allowed during the ban period. |
+| 🚫 **Permanent Ban** | Permanent ban from all community spaces. |
+
+## 🎯 GSSoC Addendum
+- Uphold GSSoC values: support, growth, and empowerment through open source.  
+- Follow all GSSoC-specific communication guidelines on Discord.  
+- Respect project admins, mentors, and fellow participants throughout the program.  
+
+## 📜 Attribution
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  
+Enforcement guidelines inspired by [Mozilla’s code of conduct enforcement ladder](https://www.mozilla.org/en-US/about/governance/policies/participation/enforcement/).
+
+---
+
+💫 **Let’s build together!**  
+By following this Code of Conduct, we create a safe, welcoming, and supportive space where everyone can learn, contribute, and grow. Thank you for being part of our community — your curiosity, creativity, and kindness make Talaash-Chat amazing! 🌱✨

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,7 @@ This Code of Conduct applies across all community spaces — including GitHub re
 
 ### For All Contributors
 Instances of abusive, harassing, or otherwise unacceptable behavior can be reported through our GitHub Issues page:  
-📌 [Report an Issue](https://github.com/imrofayel/Talaash-Chat/issues/10)  
+📌 [Report an Issue](https://github.com/imrofayel/Talaash-Chat/issues/new)  
 All complaints will be reviewed and investigated promptly and fairly. The team is committed to protecting the privacy and safety of the reporter.
 
 ### For GSSoC Contributors


### PR DESCRIPTION
This PR introduces a complete and beginner-friendly CODE_OF_CONDUCT.md for the Talaash-Chat repository.

- Implements Contributor Covenant v2.1 for all contributors
- General reporting via GitHub Issues
- GSSoC-specific section with email and Discord backup contacts
- Structured enforcement ladder for clarity
- Proper Markdown headers and clickable links for usability
- Positive, encouraging footer message to foster collaboration 🌟

Closes #10

---

Any feedback or suggestions are welcome to make this Code of Conduct even more clear, inclusive, and helpful for all contributors, including beginners.
